### PR TITLE
Add basic Barnes-Hut galaxy simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # celestial-waltz
+
+This repository contains a simple N-body simulation of a spiral galaxy. The
+simulation uses the Barnes--Hut algorithm to accelerate gravitational
+calculations and provides a small Tkinter based interface for experimenting
+with different parameters.
+
+## Requirements
+
+The code only uses the Python standard library and therefore does not require
+any third-party packages.
+
+## Running the GUI
+
+To start the simulation run:
+
+```bash
+python3 galaxy_gui.py
+```
+
+A window will appear with sliders controlling the number of particles, the time
+step, and how many iterations to run. Press **Start** to launch the simulation.
+
+## Jupyter Notebook
+
+An example notebook `example.ipynb` is included which demonstrates how to start
+the GUI from a notebook cell.

--- a/example.ipynb
+++ b/example.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Galaxy Simulation Example\n",
+    "This notebook demonstrates how to launch the Tk based galaxy simulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from galaxy_gui import GalaxyApp\n",
+    "app = GalaxyApp()\n",
+    "app.run()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/galaxy_gui.py
+++ b/galaxy_gui.py
@@ -1,0 +1,74 @@
+import tkinter as tk
+from tkinter import ttk
+import time
+
+from nbody import BarnesHutSimulation
+
+
+class GalaxyApp:
+    def __init__(self):
+        self.root = tk.Tk()
+        self.root.title("N-Body Galaxy Simulation")
+        self.canvas_size = 600
+        self.canvas = tk.Canvas(self.root, width=self.canvas_size, height=self.canvas_size, bg="black")
+        self.canvas.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+
+        controls = tk.Frame(self.root)
+        controls.pack(side=tk.BOTTOM, fill=tk.X)
+
+        self.n_var = tk.IntVar(value=200)
+        self.dt_var = tk.DoubleVar(value=0.01)
+        self.iter_var = tk.IntVar(value=200)
+
+        tk.Label(controls, text="Particles").pack(side=tk.LEFT)
+        tk.Scale(controls, from_=50, to=500, orient=tk.HORIZONTAL, variable=self.n_var).pack(side=tk.LEFT)
+        tk.Label(controls, text="Time step").pack(side=tk.LEFT)
+        tk.Scale(controls, from_=1, to=100, orient=tk.HORIZONTAL, variable=self.dt_var).pack(side=tk.LEFT)
+        tk.Label(controls, text="Iterations").pack(side=tk.LEFT)
+        tk.Scale(controls, from_=50, to=1000, orient=tk.HORIZONTAL, variable=self.iter_var).pack(side=tk.LEFT)
+        ttk.Button(controls, text="Start", command=self.start).pack(side=tk.LEFT)
+
+        self.sim = None
+        self.current_iter = 0
+
+    def start(self):
+        n = self.n_var.get()
+        dt = self.dt_var.get() / 100.0
+        iterations = self.iter_var.get()
+        self.sim = BarnesHutSimulation(num_particles=n, dt=dt)
+        self.current_iter = 0
+        self.total_iter = iterations
+        self.update_simulation()
+
+    def project(self, x, y, z):
+        distance = 3.0
+        scale = self.canvas_size / 4
+        factor = scale / (z + distance)
+        cx = self.canvas_size / 2
+        cy = self.canvas_size / 2
+        px = cx + x * factor
+        py = cy - y * factor
+        return px, py
+
+    def draw(self):
+        self.canvas.delete("all")
+        if not self.sim:
+            return
+        for p in self.sim.particles:
+            px, py = self.project(p.x, p.y, p.z)
+            self.canvas.create_oval(px-2, py-2, px+2, py+2, fill="white", outline="")
+
+    def update_simulation(self):
+        if self.sim and self.current_iter < self.total_iter:
+            self.sim.step()
+            self.current_iter += 1
+            self.draw()
+            self.root.after(10, self.update_simulation)
+
+    def run(self):
+        self.root.mainloop()
+
+
+if __name__ == "__main__":
+    app = GalaxyApp()
+    app.run()

--- a/nbody.py
+++ b/nbody.py
@@ -1,0 +1,147 @@
+import math
+import random
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+
+@dataclass
+class Particle:
+    x: float
+    y: float
+    z: float
+    vx: float
+    vy: float
+    vz: float
+    mass: float = 1.0
+
+
+class OctreeNode:
+    def __init__(self, center: Tuple[float, float, float], half_size: float):
+        self.center = list(center)
+        self.half_size = half_size
+        self.particle: Optional[Particle] = None
+        self.children: List[Optional["OctreeNode"]] = [None] * 8
+        self.mass = 0.0
+        self.com = [0.0, 0.0, 0.0]
+
+    def _is_leaf(self) -> bool:
+        return all(child is None for child in self.children)
+
+    def _subdivide(self):
+        quarter = self.half_size / 2.0
+        for i in range(8):
+            offset = (
+                quarter if i & 1 else -quarter,
+                quarter if i & 2 else -quarter,
+                quarter if i & 4 else -quarter,
+            )
+            new_center = (
+                self.center[0] + offset[0],
+                self.center[1] + offset[1],
+                self.center[2] + offset[2],
+            )
+            self.children[i] = OctreeNode(new_center, quarter)
+
+    def _child_index(self, p: Particle) -> int:
+        idx = 0
+        if p.x > self.center[0]:
+            idx |= 1
+        if p.y > self.center[1]:
+            idx |= 2
+        if p.z > self.center[2]:
+            idx |= 4
+        return idx
+
+    def insert(self, p: Particle):
+        if self._is_leaf():
+            if self.particle is None:
+                self.particle = p
+                self.mass = p.mass
+                self.com = [p.x, p.y, p.z]
+                return
+            else:
+                self._subdivide()
+                existing = self.particle
+                self.particle = None
+                self.children[self._child_index(existing)].insert(existing)
+        self.children[self._child_index(p)].insert(p)
+        # Update center of mass and mass
+        self.mass += p.mass
+        self.com[0] += p.mass * p.x
+        self.com[1] += p.mass * p.y
+        self.com[2] += p.mass * p.z
+
+    def finalize(self):
+        if self.mass > 0:
+            self.com[0] /= self.mass
+            self.com[1] /= self.mass
+            self.com[2] /= self.mass
+        if not self._is_leaf():
+            for child in self.children:
+                if child:
+                    child.finalize()
+
+    def compute_force_on(
+        self, p: Particle, theta: float = 0.5, G: float = 1.0, eps: float = 0.05
+    ) -> Tuple[float, float, float]:
+        if self.mass == 0 or (self.particle is p and self._is_leaf()):
+            return 0.0, 0.0, 0.0
+        dx = self.com[0] - p.x
+        dy = self.com[1] - p.y
+        dz = self.com[2] - p.z
+        dist = math.sqrt(dx * dx + dy * dy + dz * dz + eps * eps)
+        if self._is_leaf() or self.half_size / dist < theta:
+            factor = G * self.mass / (dist ** 3)
+            return dx * factor, dy * factor, dz * factor
+        fx = fy = fz = 0.0
+        for child in self.children:
+            if child:
+                cfx, cfy, cfz = child.compute_force_on(p, theta, G, eps)
+                fx += cfx
+                fy += cfy
+                fz += cfz
+        return fx, fy, fz
+
+
+def generate_spiral_galaxy(num: int, radius: float = 1.0) -> List[Particle]:
+    particles: List[Particle] = []
+    central_mass = num
+    G = 1.0
+    for _ in range(num):
+        r = math.sqrt(random.random()) * radius
+        angle = r * 4.0 + random.uniform(-0.2, 0.2)
+        x = r * math.cos(angle)
+        y = r * math.sin(angle)
+        z = random.gauss(0, 0.05)
+        v_mag = math.sqrt(G * central_mass / (r + 0.01))
+        vx = -v_mag * math.sin(angle)
+        vy = v_mag * math.cos(angle)
+        vz = random.gauss(0, 0.01)
+        particles.append(Particle(x, y, z, vx, vy, vz))
+    return particles
+
+
+class BarnesHutSimulation:
+    def __init__(self, num_particles: int = 100, dt: float = 0.01, theta: float = 0.5):
+        self.dt = dt
+        self.theta = theta
+        self.particles = generate_spiral_galaxy(num_particles)
+
+    def _build_tree(self) -> OctreeNode:
+        root = OctreeNode((0.0, 0.0, 0.0), 2.0)
+        for p in self.particles:
+            root.insert(p)
+        root.finalize()
+        return root
+
+    def step(self):
+        tree = self._build_tree()
+        for p in self.particles:
+            ax, ay, az = tree.compute_force_on(p, self.theta)
+            p.vx += ax * self.dt
+            p.vy += ay * self.dt
+            p.vz += az * self.dt
+        for p in self.particles:
+            p.x += p.vx * self.dt
+            p.y += p.vy * self.dt
+            p.z += p.vz * self.dt


### PR DESCRIPTION
## Summary
- implement Barnes-Hut based n-body simulator
- add a Tkinter GUI to adjust parameters with sliders and display a 3‑D projection
- include a minimal Jupyter notebook demonstrating how to start the GUI
- update README with usage instructions

## Testing
- `python3 -m py_compile nbody.py galaxy_gui.py`
- `python3 -m json.tool example.ipynb > /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_68631a8c0fcc8332a1abed044bb247ef