### PR TITLE
Add GPU simulation script and parameter documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,34 @@ python3 galaxy_gui.py
 A window will appear with sliders controlling the number of particles, the time
 step, and how many iterations to run. Press **Start** to launch the simulation.
 
+## Simulation Parameters
+
+The main parameters controlling the simulation are listed below:
+
+- **Number of Particles** – total bodies in the simulation (more particles
+  produce a more detailed galaxy but slow down execution).
+- **Time Step (dt)** – integration step in **million years**. A smaller value
+  yields more accurate dynamics at the cost of speed.
+- **Total Iterations** – number of simulation steps performed.
+- **Galaxy Type** – currently a simple spiral galaxy generator is provided.
+- **Mass Scale** and **Size Scale** – overall scaling factors for initial
+  conditions.
+- **Visualization Options** – trails, velocity vectors, and coloring by
+  velocity.
+
 ## Jupyter Notebook
 
 An example notebook `example.ipynb` is included which demonstrates how to start
 the GUI from a notebook cell.
+
+## GPU Simulation
+
+For experimentation on Google Colab or any machine with a CUDA capable GPU,
+`gpu_sim.py` provides a minimal PyTorch implementation. Install PyTorch in the
+notebook and run:
+
+```python
+!python gpu_sim.py --particles 100000 --iterations 1000 --dt 0.01
+```
+
+The command line flags allow choosing the number of particles and iterations.

--- a/gpu_sim.py
+++ b/gpu_sim.py
@@ -1,0 +1,48 @@
+import argparse
+import torch
+
+def generate_spiral_galaxy(num, radius=1.0, device="cuda"):
+    central_mass = num
+    G = 1.0
+    r = torch.sqrt(torch.rand(num, device=device)) * radius
+    angle = r * 4.0 + (torch.rand(num, device=device) * 0.4 - 0.2)
+    x = r * torch.cos(angle)
+    y = r * torch.sin(angle)
+    z = torch.randn(num, device=device) * 0.05
+    v_mag = torch.sqrt(G * central_mass / (r + 0.01))
+    vx = -v_mag * torch.sin(angle)
+    vy = v_mag * torch.cos(angle)
+    vz = torch.randn(num, device=device) * 0.01
+    pos = torch.stack((x, y, z), dim=1)
+    vel = torch.stack((vx, vy, vz), dim=1)
+    mass = torch.ones(num, device=device)
+    return pos, vel, mass
+
+def step(pos, vel, mass, dt, G=1.0, eps=0.05):
+    diff = pos.unsqueeze(1) - pos.unsqueeze(0)
+    dist_sqr = (diff ** 2).sum(-1) + eps ** 2
+    inv_dist3 = dist_sqr.pow(-1.5)
+    accel = (diff * inv_dist3.unsqueeze(-1) * mass.view(1, -1, 1)).sum(1) * G
+    vel += accel * dt
+    pos += vel * dt
+
+
+def run(n_particles, iterations, dt, device=None):
+    device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+    pos, vel, mass = generate_spiral_galaxy(n_particles, device=device)
+    for _ in range(iterations):
+        step(pos, vel, mass, dt)
+    return pos, vel
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GPU accelerated N-body simulation")
+    parser.add_argument("--particles", type=int, default=100000, help="Number of particles")
+    parser.add_argument("--iterations", type=int, default=1000, help="Number of iterations")
+    parser.add_argument("--dt", type=float, default=0.01, help="Time step in Myr")
+    args = parser.parse_args()
+    run(args.particles, args.iterations, args.dt)
+
+
+if __name__ == "__main__":
+    main()

--- a/nbody.py
+++ b/nbody.py
@@ -16,6 +16,8 @@ class Particle:
 
 
 class OctreeNode:
+    MIN_SIZE = 1e-5
+
     def __init__(self, center: Tuple[float, float, float], half_size: float):
         self.center = list(center)
         self.half_size = half_size
@@ -58,6 +60,13 @@ class OctreeNode:
                 self.particle = p
                 self.mass = p.mass
                 self.com = [p.x, p.y, p.z]
+                return
+            elif self.half_size < self.MIN_SIZE:
+                # Avoid infinite subdivision when particles overlap closely
+                self.mass += p.mass
+                self.com[0] += p.mass * p.x
+                self.com[1] += p.mass * p.y
+                self.com[2] += p.mass * p.z
                 return
             else:
                 self._subdivide()


### PR DESCRIPTION
## Summary
- add `MIN_SIZE` threshold in `OctreeNode` to avoid recursion errors
- document simulation parameters and GPU usage in `README`
- implement `gpu_sim.py` using PyTorch for running on GPU

## Testing
- `python3 -m py_compile gpu_sim.py nbody.py galaxy_gui.py`
- `python3 gpu_sim.py --particles 10 --iterations 1 --dt 0.01` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68631d4648fc8332a06e182dd329fc83