### PR TITLE
Add simple simulation recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ The main parameters controlling the simulation are listed below:
 ## Jupyter Notebook
 
 An example notebook `example.ipynb` is included which demonstrates how to start
-the GUI from a notebook cell.
+the GUI from a notebook cell. It also shows how to record a short simulation
+sequence to disk using `SimulationRecorder`.
 
 ## GPU Simulation
 

--- a/example.ipynb
+++ b/example.ipynb
@@ -1,36 +1,50 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Galaxy Simulation Example\n",
-    "This notebook demonstrates how to launch the Tk based galaxy simulation."
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Galaxy Simulation Example\n",
+        "This notebook demonstrates how to launch the Tk based galaxy simulation."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from galaxy_gui import GalaxyApp\n",
+        "app = GalaxyApp()\n",
+        "app.run()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from nbody import BarnesHutSimulation\n",
+        "from recorder import SimulationRecorder\n",
+        "rec = SimulationRecorder(200)\n",
+        "sim = BarnesHutSimulation(num_particles=200, dt=0.01, recorder=rec)\n",
+        "sim.run(100)\n",
+        "rec.save('simulation.bin')"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from galaxy_gui import GalaxyApp\n",
-    "app = GalaxyApp()\n",
-    "app.run()"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.12"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/nbody.py
+++ b/nbody.py
@@ -131,10 +131,11 @@ def generate_spiral_galaxy(num: int, radius: float = 1.0) -> List[Particle]:
 
 
 class BarnesHutSimulation:
-    def __init__(self, num_particles: int = 100, dt: float = 0.01, theta: float = 0.5):
+    def __init__(self, num_particles: int = 100, dt: float = 0.01, theta: float = 0.5, recorder=None):
         self.dt = dt
         self.theta = theta
         self.particles = generate_spiral_galaxy(num_particles)
+        self.recorder = recorder
 
     def _build_tree(self) -> OctreeNode:
         root = OctreeNode((0.0, 0.0, 0.0), 2.0)
@@ -154,3 +155,10 @@ class BarnesHutSimulation:
             p.x += p.vx * self.dt
             p.y += p.vy * self.dt
             p.z += p.vz * self.dt
+
+        if self.recorder is not None:
+            self.recorder.add_frame(self.particles)
+
+    def run(self, iterations: int):
+        for _ in range(iterations):
+            self.step()

--- a/recorder.py
+++ b/recorder.py
@@ -1,0 +1,38 @@
+"""Simple recording of simulation frames for playback."""
+
+import struct
+from typing import Iterable, List, Tuple
+
+
+class SimulationRecorder:
+    """Record particle positions for each simulation step."""
+
+    def __init__(self, particle_count: int):
+        self.particle_count = particle_count
+        self.frames: List[List[Tuple[float, float, float]]] = []
+
+    def add_frame(self, particles: Iterable[Tuple[float, float, float]]):
+        self.frames.append([(p.x, p.y, p.z) for p in particles])
+
+    def save(self, path: str):
+        """Write recorded frames to a binary file."""
+        with open(path, "wb") as f:
+            header = struct.pack("III", len(self.frames), self.particle_count, 3)
+            f.write(header)
+            for frame in self.frames:
+                for x, y, z in frame:
+                    f.write(struct.pack("fff", x, y, z))
+
+    @classmethod
+    def load(cls, path: str):
+        with open(path, "rb") as f:
+            header = f.read(12)
+            frames, count, comps = struct.unpack("III", header)
+            recorder = cls(count)
+            for _ in range(frames):
+                data = []
+                for _ in range(count):
+                    xyz = struct.unpack("fff", f.read(12))
+                    data.append(xyz)
+                recorder.frames.append(data)
+        return recorder


### PR DESCRIPTION
## Summary
- add `SimulationRecorder` for saving positions to a binary file
- update BarnesHutSimulation to optionally record frames and provide run helper
- extend notebook with example of recording a short run
- document recorder usage in README

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_686321e6e9108332bacb9bedd7b4967e